### PR TITLE
Apply listen-only mode requested via ip link

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,11 @@
 #define SIOCGCLIENTVEROK		0x3009
 #define SIOCSBAUDRATE			0x300A
 
+/* Flag bits encoded by the kernel module into intrepid_pending_tx_info.count
+ * when reporting a settings change (tx_box_index < 0). Must match intrepid.c. */
+#define INTREPID_BITRATE_FLAG_LISTENONLY	(1 << 30)
+#define INTREPID_BITRATE_VALUE_MASK		(INTREPID_BITRATE_FLAG_LISTENONLY - 1)
+
 #define RX_BOX_SIZE			(sharedMemSize / (maxInterfaces * 2))
 #define TX_BOX_SIZE			(sharedMemSize / 4)
 #define GET_RX_BOX(DEVICE_INDEX)	(reinterpret_cast<uint8_t*>(sharedMemory) + (RX_BOX_SIZE * DEVICE_INDEX))
@@ -894,30 +899,66 @@ int main(int argc, char** argv) {
 				stopRunning = true;
 				break;
 			} else if (info.tx_box_index < 0) {
-				// Baudrate changed in kernel
+				// Baudrate and/or control mode changed in kernel
 				int dev_idx = -(info.tx_box_index + 1);
-				LOGF(LOG_INFO, "Baudrate change, device %d, baudrate %d fd_baudrate %ld\n",
-					dev_idx, info.count, info.bytes);
+				const bool listenOnly = (info.count & INTREPID_BITRATE_FLAG_LISTENONLY) != 0;
+				const int64_t baudrate = info.count & INTREPID_BITRATE_VALUE_MASK;
+				LOGF(LOG_INFO, "Settings change, device %d, baudrate %ld fd_baudrate %zu listen_only %d\n",
+					dev_idx, (long)baudrate, info.bytes, listenOnly ? 1 : 0);
 				/* fd baudrate is zero if fd mode is disabled in kernel
 				 * set fd baudrate equal to baudrate */
 				if (info.bytes == 0) {
-					info.bytes = info.count;
+					info.bytes = baudrate;
 				}
-				for(auto& dev : openDevices) {
-					for(auto& netifPair : dev.interfaces) {
-						auto netid = netifPair.first;
-						if(netifPair.second->getKernelHandle() != dev_idx)
-							continue;
-						if (! dev.device->settings->setBaudrateFor(netid, info.count) ) {
-							LOGF(LOG_ERR, "Unable to set baudrate for device %s\n",
-								netifPair.second->getName().c_str());
-						} else if (! dev.device->settings->setFDBaudrateFor(netid, info.bytes)) {
-							LOGF(LOG_ERR, "Unable to set fd baudrate for device %s\n",
-								netifPair.second->getName().c_str());
-						} else if (! dev.device->settings->apply()) {
-							LOGF(LOG_ERR, "Unable to apply settings for device %s\n",
-								netifPair.second->getName().c_str());
+				/* Find the target device under the lock, but stage and apply the
+				 * settings outside of it: IDeviceSettings::apply() can block for
+				 * several seconds and must not hold openDevicesMutex against the
+				 * device-search and RPC threads for that long. The shared_ptr
+				 * keeps the device alive if the search thread drops it
+				 * concurrently. */
+				std::shared_ptr<icsneo::Device> targetDevice;
+				icsneo::Network::NetID targetNetid{};
+				std::string targetName;
+				{
+					std::lock_guard<std::mutex> lg(openDevicesMutex);
+					for(auto& dev : openDevices) {
+						for(auto& netifPair : dev.interfaces) {
+							if(netifPair.second->getKernelHandle() != dev_idx)
+								continue;
+							targetDevice = dev.device;
+							targetNetid = netifPair.first;
+							targetName = netifPair.second->getName();
+							break;
 						}
+						if(targetDevice)
+							break;
+					}
+				}
+				/* Stage the baudrates before the control mode so a rejected
+				 * baudrate cannot leave a partially staged mode change behind. */
+				if (!targetDevice) {
+					LOGF(LOG_ERR, "Settings change for unknown device handle %d\n", dev_idx);
+				} else if (! targetDevice->settings->setBaudrateFor(targetNetid, baudrate) ) {
+					LOGF(LOG_ERR, "Unable to set baudrate for device %s\n", targetName.c_str());
+				} else if (! targetDevice->settings->setFDBaudrateFor(targetNetid, info.bytes)) {
+					LOGF(LOG_ERR, "Unable to set fd baudrate for device %s\n", targetName.c_str());
+				} else {
+					CAN_SETTINGS* canCfg = targetDevice->settings->getMutableCANSettingsFor(targetNetid);
+					if (canCfg != nullptr) {
+						/* Only toggle between NORMAL and LISTEN_ONLY here. Other
+						 * modes (LOOPBACK, LISTEN_ALL, DISABLE) may have been
+						 * configured with other tools and are left untouched by
+						 * bitrate-only changes. */
+						if (listenOnly)
+							canCfg->Mode = LISTEN_ONLY;
+						else if (canCfg->Mode == LISTEN_ONLY)
+							canCfg->Mode = NORMAL;
+					} else if (listenOnly) {
+						LOGF(LOG_ERR, "Listen-only requested but no CAN settings for device %s\n",
+							targetName.c_str());
+					}
+					if (! targetDevice->settings->apply()) {
+						LOGF(LOG_ERR, "Unable to apply settings for device %s\n", targetName.c_str());
 					}
 				}
 			} else {


### PR DESCRIPTION
Companion to intrepidcs/intrepid-socketcan-kernel-module#27; the two are meant to
land together.

The kernel module encodes `CAN_CTRLMODE_LISTENONLY` in bit 30 of the settings-change
report. This PR masks the flag out of the bitrate and toggles `CAN_SETTINGS.Mode`
between `LISTEN_ONLY` and `NORMAL` through
`IDeviceSettings::getMutableCANSettingsFor()`, alongside the existing baudrate
handling.

Design decisions (please push back if you disagree):

- The mode is only toggled between NORMAL and LISTEN_ONLY. Other modes (LOOPBACK,
  LISTEN_ALL, DISABLE) that may have been configured with other tools are left
  untouched by bitrate-only changes.
- The mode is staged only after both baudrates were accepted, so a rejected baudrate
  cannot leave a half-staged mode in the settings buffer (which a later unrelated
  apply() would otherwise flush to the device).
- The device lookup now takes `openDevicesMutex`: this branch previously scanned
  `openDevices` unlocked while the search thread can erase entries (this is the
  branch the PR extends, so the fix is included here rather than split out).
  Settings are staged and applied outside the lock so the search and RPC threads
  are not blocked while `IDeviceSettings::apply()` runs, which can take several
  seconds.
- `settings->apply()` persists to EEPROM, same as the existing baudrate path. That
  means a listen-only setting survives daemon shutdown and is visible to other tools
  (we hit exactly this during testing: a device left in listen-only kept withholding
  ACKs on a bench bus afterwards, failing every other node's transmissions). If you
  would rather use volatile settings (`apply(true)`) for ip-link-driven changes, I
  can change it, though that would also change the existing baudrate behavior.
- CMakeLists is already at VERSION 3.2.0 on master, which is what the kernel module's
  version gate expects, so no version bump is included.

Tested end-to-end on Ubuntu 22.04.5 with a neoVI FIRE 3 and a ValueCAN 4-2, each
exercised as the SocketCAN device (details in the kernel PR), with
`LIBICSNEO_USE_SERVD=0` set for discovery (stock discovery is currently affected by #21). The daemon logs the decoded request:

    Settings change, device 0, baudrate 500000 fd_baudrate 0 listen_only 1
